### PR TITLE
Allow database to exist when creating without failing

### DIFF
--- a/src/Console/Commands/DbCreateCommand.php
+++ b/src/Console/Commands/DbCreateCommand.php
@@ -15,7 +15,8 @@ class DbCreateCommand extends Command
      * @var string
      */
     protected $signature = 'db:create
-                                {database? : Database to create. If omitted, name from .env will be used.}';
+                                {database? : Database to create. If omitted, name from .env will be used.}
+                                {--allow-existing : Exit successfully even if the database already exists.}';
 
     /**
      * The console command description.
@@ -35,6 +36,12 @@ class DbCreateCommand extends Command
             ?: config('database.connections.' . config('database.default') . '.database');
 
         if ($this->dbHandler()->databaseExists($database)) {
+            if ($this->option('allow-existing')) {
+                $this->output->info("Database `$database` exists");
+
+                return 0;
+            }
+
             $this->output->warning("Database `$database` exists");
 
             return 1;

--- a/tests/Unit/Commands/DbCreateCommandTest.php
+++ b/tests/Unit/Commands/DbCreateCommandTest.php
@@ -24,6 +24,19 @@ class DbCreateCommandTest extends TestCase
     /**
      * @test
      */
+    public function it_returns_0_when_allowing_db_to_exist()
+    {
+        $this->mock(AbstractDbHandler::class, function (MockInterface $mock) {
+            $mock->shouldReceive('databaseExists')->once()->andReturn(true);
+        });
+
+        $this->artisan('db:create', ['--allow-existing' => true])
+            ->assertExitCode(0);
+    }
+
+    /**
+     * @test
+     */
     public function it_returns_0_when_db_created()
     {
         $database = 'non_existent_db';


### PR DESCRIPTION
I want to use this command as part of a development environment setup script, so I want to create the database on first run but simply move on if it already exists.